### PR TITLE
Extended http problem details with more data

### DIFF
--- a/src/Cedar.HttpCommandHandling.Client/HttpProblemDetails.cs
+++ b/src/Cedar.HttpCommandHandling.Client/HttpProblemDetails.cs
@@ -74,7 +74,7 @@
             }
         }
 
-        internal HttpProblemDetailsDto GetDto()
+        public virtual HttpProblemDetailsDto GetDto()
         {
             return new HttpProblemDetailsDto
             {

--- a/src/Cedar.HttpCommandHandling.Client/HttpProblemDetailsDto.cs
+++ b/src/Cedar.HttpCommandHandling.Client/HttpProblemDetailsDto.cs
@@ -1,6 +1,6 @@
 ﻿namespace Cedar.HttpCommandHandling
 {
-    internal class HttpProblemDetailsDto
+    public class HttpProblemDetailsDto
     {
         public int Status { get; set; }
 

--- a/src/Cedar.HttpCommandHandling.Tests/Cedar.HttpCommandHandling.Tests.csproj
+++ b/src/Cedar.HttpCommandHandling.Tests/Cedar.HttpCommandHandling.Tests.csproj
@@ -44,6 +44,7 @@
       <HintPath>..\packages\FluentAssertions.3.2.2\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin">
       <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>

--- a/src/Cedar.HttpCommandHandling.Tests/CommandHandlingFixture.cs
+++ b/src/Cedar.HttpCommandHandling.Tests/CommandHandlingFixture.cs
@@ -33,6 +33,19 @@ namespace Cedar.HttpCommandHandling
                     };
                     throw new HttpProblemDetailsException(problemDetails);
                 });
+            module.For<TestCommandWhoseHandlerThrowExtendedProblemDetailsException>()
+                .Handle((_, __) =>
+                {
+                    var extendedProblemDetails = new ExtendedHttpProblemDetails(HttpStatusCode.BadRequest)
+                    {
+                        Type = new Uri("http://localhost/type"),
+                        Detail = "You done goof'd",
+                        Instance = new Uri("http://localhost/errors/1"),
+                        Title = "Jimmies Ruslted",
+                        Extension = "Some more data"
+                    };
+                    throw new HttpProblemDetailsException(extendedProblemDetails);
+                });
             module.For<TestCommandWhoseHandlerThrowsExceptionThatIsConvertedToProblemDetails>()
                .Handle((_, __) => { throw new ApplicationException("Custom application exception"); });
 
@@ -79,6 +92,33 @@ namespace Cedar.HttpCommandHandling
 
     public class TestCommandWhoseHandlerThrowProblemDetailsException { }
 
+    public class TestCommandWhoseHandlerThrowExtendedProblemDetailsException {}
+
     public class TestCommandWhoseHandlerThrowsExceptionThatIsConvertedToProblemDetails { }
 
+    public class ExtendedHttpProblemDetails : HttpProblemDetails
+    {
+        public ExtendedHttpProblemDetails(HttpStatusCode status): base(status)
+        {}
+
+        public string Extension { get; set; }
+
+        public override HttpProblemDetailsDto GetDto()
+        {
+            return new ExtendedHttpProblemDetailsDto
+            {
+                Detail = Detail,
+                Status = (int)Status,
+                Instance = Instance != null ? Instance.ToString() : null,
+                Title = Title,
+                Type = Type != null ? Type.ToString() : null,
+                Extension = Extension
+            };
+        }
+    }
+
+    public class ExtendedHttpProblemDetailsDto : HttpProblemDetailsDto
+    {
+        public string Extension { get; set; }
+    }
 }

--- a/src/Cedar.HttpCommandHandling.Tests/CommandHandlingTests.cs
+++ b/src/Cedar.HttpCommandHandling.Tests/CommandHandlingTests.cs
@@ -71,6 +71,26 @@
         }
 
         [Fact]
+        public void When_put_command_whose_handler_throws_extended_http_problem_details_exception_then_should_throw()
+        {
+            using (var client = _fixture.CreateHttpClient())
+            {
+                Func<Task> act = () => client.PutCommand(new TestCommandWhoseHandlerThrowExtendedProblemDetailsException(), Guid.NewGuid());
+
+                var exception = act.ShouldThrow<HttpProblemDetailsException>().And;
+
+                exception.ProblemDetails.Should().NotBeNull();
+
+                dynamic problemDetails = exception.ProblemDetails;
+                ((object)problemDetails.Instance).Should().NotBeNull();
+                ((object)problemDetails.Detail).Should().NotBeNull();
+                ((object)problemDetails.Title).Should().NotBeNull();
+                ((object)problemDetails.Type).Should().NotBeNull();
+                //((object)problemDetails.Extension).Should().NotBeNull();
+            }
+        }
+
+        [Fact]
         public void When_put_command_whose_handler_throws_exception_mapped_to_http_problem_details_exception_then_should_throw()
         {
             using (var client = _fixture.CreateHttpClient())


### PR DESCRIPTION
Damian,

Please take a look at this for extending HttpProblemDetails with Extension Members as per the [Problem Details for HTTP APIs draft 3.2](https://tools.ietf.org/html/draft-nottingham-http-problem-06#section-3.2)

I am not really happy with having to create an additional DTO and overriding the GetDto() function. Feels like just deriving from HttpProblemDetails should be enough.